### PR TITLE
Added link to official Ubuntu MAAS website

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -207,7 +207,7 @@ Single MAAS cluster service [multiple racks]
 Read more
 =========
 
-* 
+* https://maas.io/
 
 Documentation and Bugs
 ======================


### PR DESCRIPTION
Added link to official Ubuntu MAAS website in the 'Read more' section of README.rst.