### PR TITLE
module: Obtain fabric ID from CIDR

### DIFF
--- a/_modules/maas.py
+++ b/_modules/maas.py
@@ -206,7 +206,8 @@ class Subnet(MaasObject):
     def fill_data(self, name, subnet, fabrics):
         data = {
             'name': name,
-            'fabric': str(fabrics[subnet.get('fabric', '')]),
+            'fabric': str(fabrics[subnet.get('fabric',
+                self._get_fabric_from_cidr(subnet.get('cidr')))]),
             'cidr': subnet.get('cidr'),
             'gateway_ip': subnet['gateway_ip'],
         }
@@ -222,6 +223,13 @@ class Subnet(MaasObject):
         res_json = json.loads(response)
         self._process_iprange(res_json['id'])
         return response
+
+    def _get_fabric_from_cidr(self, cidr):
+        subnets = json.loads(self._maas.get(u'api/2.0/subnets/').read())
+        for subnet in subnets:
+            if subnet['cidr'] == cidr:
+                return subnet['vlan']['fabric']
+        return ''
 
     def _process_iprange(self, subnet_id):
         ipranges = json.loads(self._maas.get(u'api/2.0/ipranges/').read())


### PR DESCRIPTION
MaaS subnet update requires specifying the correct fabric via reclass,
which we used to hardcode in our reclass model.
However, fabric index numbers are not deterministic, especially when
using a fabric other than 'fabric-0'.

Update MaaS custom py module to determine fabric name/ID on the
fly, based on CIDR matching (assuming we don't have CIDR conflicts).

This change maintains backwards compatibility:
- if fabric is specified via reclass model, it will be used as-is;
- if fabric is not specified via reclass model, we try to deduce it
  based on CIDR; if no match is found, the old default ('') is used;