### PR TITLE
maas.py: Add missing status ids

### DIFF
--- a/_modules/maas.py
+++ b/_modules/maas.py
@@ -52,7 +52,10 @@ STATUS_NAME_DICT = dict([
     (9, 'Deploying'), (6, 'Deployed'), (7, 'Retired'), (8, 'Broken'),
     (11, 'Failed deployment'), (12, 'Releasing'),
     (13, 'Releasing failed'), (14, 'Disk erasing'),
-    (15, 'Failed disk erasing')])
+    (15, 'Failed disk erasing'), (16, 'Rescue mode'),
+    (17, 'Entering rescue mode'), (18, 'Failed to enter rescue mode'),
+    (19, 'Exiting rescue mode'), (20, 'Failed to exit rescue mode'),
+    (21, 'Testing'), (22, 'Failed testing')])
 
 
 def _format_data(data):


### PR DESCRIPTION
Status ID list synced from MaaS 2.3 [1].

[1] https://github.com/maas/maas/blob/2.3/src/maasserver/\
    migrations/builtin/maasserver/0106_testing_status.py#L25

This fixes a rare issue where nodes get in a weird state (in my case 'Failed testing' due to errors installing the smartctl package via proxy):

> ----------
>           ID: check_machines_status
>     Function: module.run
>         Name: maas.machines_status
>       Result: False
>      Comment: Module function maas.machines_status threw an exception. Exception: 22
>      Started: 05:09:57.973216
>     Duration: 3046.879 ms
>      Changes:

After this change + sync_all:
> ----------
>           ID: check_machines_status
>     Function: module.run
>         Name: maas.machines_status
>       Result: True
>      Comment: Module function maas.machines_status executed
>      Started: 05:21:50.571652
>     Duration: 3275.842 ms
>      Changes:
>               ----------
>               ret:
>                   ----------
>                   machines:
>                       |_
>                         ----------
>                         hostname:
>                             cmp002
>                         status:
>                             Failed testing
>                         system_id:
>                             dk8mpq
>                       |_
>                         ----------
>                         hostname:
>                             cmp001
>                         status:
>                             Failed commissioning
>                         system_id:
>                             m3yp46
>                       |_
> [...]