### PR TITLE
curtin: Add curtin_userdata_arm64_generic_xenial

### DIFF
--- a/maas/files/curtin_userdata_arm64_generic_xenial
+++ b/maas/files/curtin_userdata_arm64_generic_xenial
@@ -1,0 +1,44 @@
+{%- from "maas/map.jinja" import cluster with context %}
+{% raw %}
+#cloud-config
+debconf_selections:
+ maas: |
+  {{for line in str(curtin_preseed).splitlines()}}
+  {{line}}
+  {{endfor}}
+{{if third_party_drivers and driver}}
+early_commands:
+  {{py: key_string = ''.join(['\\x%x' % x for x in map(ord, driver['key_binary'])])}}
+  driver_00_get_key: /bin/echo -en '{{key_string}}' > /tmp/maas-{{driver['package']}}.gpg
+  driver_01_add_key: ["apt-key", "add", "/tmp/maas-{{driver['package']}}.gpg"]
+  driver_02_add: ["add-apt-repository", "-y", "deb {{driver['repository']}} {{node.get_distro_series()}} main"]
+  driver_03_update_install: ["sh", "-c", "apt-get update --quiet && apt-get --assume-yes install {{driver['package']}}"]
+  driver_04_load: ["sh", "-c", "depmod && modprobe {{driver['module']}}"]
+{{endif}}
+late_commands:
+  maas: [wget, '--no-proxy', {{node_disable_pxe_url|escape.json}}, '--post-data', {{node_disable_pxe_data|escape.json}}, '-O', '/dev/null']
+{% endraw %}
+{%- if not cluster.saltstack_repo_key == 'none' %}
+{% set salt_repo_key = salt['hashutil.base64_b64encode'](cluster.saltstack_repo_key) %}
+  apt_00_set_gpg: ["curtin", "in-target", "--", "sh", "-c", "echo '{{salt_repo_key}}' | base64 -d | apt-key add -"]
+{%- endif %}
+{#- NOTE: Re-use amd64 repos on arm64 since most packages are arch independent -#}
+  apt_01_set_repo: ["curtin", "in-target", "--", "sh", "-c", "echo 'deb [arch=amd64] {{ cluster.saltstack_repo_xenial }}' >> /etc/apt/sources.list"]
+{% raw %}
+  apt_03_update: ["curtin", "in-target", "--", "apt-get", "update"]
+  salt_01_install: ["curtin", "in-target", "--", "apt-get", "-y", "install", "python-futures", "salt-minion"]
+{% endraw %}
+  salt_02_hostname_set: ["curtin", "in-target", "--", "echo", "{% raw %}{{node.hostname}}{% endraw %}.{{pillar.linux.system.domain}}"]
+  salt_03_hostname_get: ["curtin", "in-target", "--", "sh", "-c", "echo 'id: {% raw %}{{node.hostname}}{% endraw %}.{{pillar.linux.system.domain}}' >> /etc/salt/minion"]
+  salt_04_master: ["curtin", "in-target", "--", "sh", "-c", "echo 'master: {{ salt_master_ip }}' >> /etc/salt/minion"]
+{% raw %}
+{{if third_party_drivers and driver}}
+  driver_00_key_get: curtin in-target -- sh -c "/bin/echo -en '{{key_string}}' > /tmp/maas-{{driver['package']}}.gpg"
+  driver_02_key_add: ["curtin", "in-target", "--", "apt-key", "add", "/tmp/maas-{{driver['package']}}.gpg"]
+  driver_03_add: ["curtin", "in-target", "--", "add-apt-repository", "-y", "deb {{driver['repository']}} {{node.get_distro_series()}} main"]
+  driver_04_update_install: ["curtin", "in-target", "--", "apt-get", "update", "--quiet"]
+  driver_05_install: ["curtin", "in-target", "--", "apt-get", "-y", "install", "{{driver['package']}}"]
+  driver_06_depmod: ["curtin", "in-target", "--", "depmod"]
+  driver_07_update_initramfs: ["curtin", "in-target", "--", "update-initramfs", "-u"]
+{{endif}}
+{% endraw %}

--- a/maas/region.sls
+++ b/maas/region.sls
@@ -97,6 +97,18 @@ maas_apache_headers:
   - require:
     - pkg: maas_region_packages
 
+/etc/maas/preseeds/curtin_userdata_arm64_generic_xenial:
+  file.managed:
+  - source: salt://maas/files/curtin_userdata_arm64_generic_xenial
+  - template: jinja
+  - user: root
+  - group: root
+  - mode: 644
+  - context:
+      salt_master_ip: {{ region.salt_master_ip }}
+  - require:
+    - pkg: maas_region_packages
+
 /root/.pgpass:
   file.managed:
   - source: salt://maas/files/pgpass


### PR DESCRIPTION
Trusty has very limited support for AArch64, so it only makes
sense to add Xenial curtin templates.

NOTE: Current arm64 template will use the 'amd64' Saltstack repos,
as most required packages are arch-independent.
Pillar salt repo key and URL for amd64 are also used on arm64.
This, coupled with the current state of the Ubuntu Xenial repos,
leads to the following (AArch64 only):
- RAET is not supported out of the box (arch-specific binaries are
  required, yet Ubuntu lacks one or more of them);
- python-tornado from Ubuntu does not depend on python-futures,
  so we install it explicitly via Curtin;