### PR TITLE
Fix module calls in maasng, extend VLAN configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -202,7 +202,7 @@ Multiple ip ranges for one particular subnet.
               comment: 'Comment 2'
 
 
-Update Vlan
+Update Vlan based on fabric name
 
 NOTE: Vid 0 has default name untagged in MaaS UI
 
@@ -213,6 +213,24 @@ NOTE: Vid 0 has default name untagged in MaaS UI
       fabrics:
         test-fabric:
           description: "Test fabric"
+          vlan:
+            0:
+              description: "Your VLAN 0"
+              dhcp: True
+            13:
+              description: "Your VLAN 13"
+              dhcp: False
+
+Update Vlan based on subnet CIDR (if maas:region:fabrics is not defined)
+
+.. code-block:: yaml
+
+  maas:
+    region:
+      subnets:
+        subnet1:
+          fabric: fabric-2  # Created by MaaS based on network interfaces
+          cidr: 2.2.3.0/24  # cidr is used to match this subnet to its fabric
           vlan:
             0:
               description: "Your VLAN 0"

--- a/_modules/maasng.py
+++ b/_modules/maasng.py
@@ -966,7 +966,12 @@ def get_fabricid(fabric):
     try:
         return list_fabric()[fabric]['id']
     except KeyError:
-        return {"error": "Frabic not found on MaaS server"}
+        # fabric might be specified as CIDR, try to find the actual fabric ID
+        maas_subnets = list_subnet()
+        for subnet in maas_subnets.keys():
+            if maas_subnets[subnet]['cidr'] == fabric:
+                return maas_subnets[subnet]['vlan']['fabric_id']
+        return {"error": "Fabric not found on MaaS server"}
 
 
 def update_vlan(name, fabric, vid, description, primary_rack, dhcp_on=False):

--- a/maas/region.sls
+++ b/maas/region.sls
@@ -375,7 +375,7 @@ maas_update_vlan_for_{{ fabric_name }}_{{ vid }}:
   maasng.update_vlan:
   - vid: {{ vid }}
   - fabric: {{ fabric_name }}
-  - name: {{ vlan.get('name','') }}
+  - name: '{{ vlan.get('name', vid) }}'
   - description: {{ vlan.description }}
   - primary_rack: {{ region.maas_config.maas_name }}
   - dhcp_on: {{ vlan.get('dhcp','False') }}

--- a/maas/region.sls
+++ b/maas/region.sls
@@ -306,6 +306,19 @@ maas_create_subnet_{{ subnet_name }}:
 {%- endfor %}
 
 {%- for subnet_name, subnet in region.subnets.iteritems() %}
+{%- for vid, vlan in subnet.get('vlan', {}).items() %}
+maas_update_vlan_for_{{ subnet_name }}_{{ vid }}:
+  maasng.update_vlan:
+  - vid: {{ vid }}
+  - fabric: {{ subnet.cidr }}
+  - name: '{{ vlan.get('name', vid) }}'
+  - description: {{ vlan.description }}
+  - primary_rack: {{ region.maas_config.maas_name }}
+  - dhcp_on: {{ vlan.get('dhcp','False') }}
+{%- endfor %}
+{%- endfor %}
+
+{%- for subnet_name, subnet in region.subnets.iteritems() %}
 {%- if subnet.get('multiple') == True %}
 {%- for range_name, iprange in subnet.get('iprange',{}).items() %}
 maas_create_ipranger_{{ range_name }}:


### PR DESCRIPTION
Fabrics are not deterministically created by MaaS, so determine the fabric ID for a VLAN based on the corresponding subnet.
While at it, fix broken handling of 'name' arguments, which would trigger a MaaS API PUT fail in certain scenarios.