### PR TITLE
Maasng delete machine

### DIFF
--- a/_modules/maasng.py
+++ b/_modules/maasng.py
@@ -128,7 +128,7 @@ def get_machine(hostname):
         return {"error": "Machine not found on MaaS server"}
 
 
-def list_machines():
+def list_machines(status_filter=None):
     """
     Get list of all machines from maas server
 
@@ -137,12 +137,14 @@ def list_machines():
     .. code-block:: bash
 
         salt 'maas-node' maasng.list_machines
+        salt 'maas-node' maasng.list_machines status_filter=[Deployed,Ready]
     """
     machines = {}
     maas = _create_maas_client()
     json_res = json.loads(maas.get(u'api/2.0/machines/').read())
     for item in json_res:
-        machines[item["hostname"]] = item
+        if not status_filter or item['status_name'] in status_filter:
+            machines[item["hostname"]] = item
     return machines
 
 

--- a/_modules/maasng.py
+++ b/_modules/maasng.py
@@ -159,6 +159,56 @@ def update_machine():
 
     return False
 
+def delete_machine(hostname):
+    """
+    Delete specified machine
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'maas-node' maasng.delete_machine server_hostname
+        salt-call maasng.delete_machine server_hostname
+    """
+    result = {}
+    maas = _create_maas_client()
+    system_id = get_machine(hostname)["system_id"]
+    LOG.debug('delete_machine: {}'.format(system_id))
+    maas.delete(
+        u"api/2.0/machines/{0}/".format(system_id)).read()
+
+    result["new"] = "Machine {0} deleted".format(hostname)
+    return result
+
+def action_machine(hostname, action, comment=None):
+    """
+    Send simple action (e.g. mark_broken, mark_fixed) to machine.
+
+    :param action:  Action to send for machine (one of MaaS' op codes)
+    :param comment: Optional comment for the event log.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'maas-node' maasng.action_machine server_hostname mark_broken comment='dead'
+    """
+    result = {}
+    data = {}
+    maas = _create_maas_client()
+    system_id = get_machine(hostname)["system_id"]
+    LOG.debug('action_machine: {}'.format(system_id))
+
+    # TODO validation
+    if comment:
+        data["comment"] = comment
+    json_res = json.loads(maas.post(
+        u"api/2.0/machines/{0}/".format(system_id), action, **data).read())
+    LOG.info(json_res)
+    result["new"] = "Machine {0} action {1} executed".format(hostname, action)
+
+    return result
+
 # END MACHINE SECTION
 # RAID SECTION
 


### PR DESCRIPTION
Add 2 more useful functions, required only if things break in MaaS (e.g. failed deploy / failed testing etc.).
Later, these might be leveraged in _states/maasng.py to provide an idempotent stateful approach to machines.deploy (including parametric retries where we automatically delete the machine and re-add it a few times and/or mark it broken/fixed to bypass commissioning/deployment errors).