### PR TITLE
Wait for attempts, attempt automatic recovery

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -607,11 +607,15 @@ Wait for status of selected machine's:
             machines:
               - kvm01
               - kvm02
-            timeout: 1200 # in seconds
+            timeout: {{ region.timeout.ready }}
+            attempts: {{ region.timeout.attempts }}
             req_status: "Ready"
       - require:
         - cmd: maas_login_admin
       ...
+
+The timeout setting is taken from the reclass pillar data.
+If the pillar data is not defined, it will use the default value.
 
 If module run w/\o any extra paremeters,
 ``wait_for_machines_ready`` will wait for defined in salt
@@ -627,7 +631,8 @@ machines. In this case, it is usefull to skip some machines:
       module.run:
       - name: maas.wait_for_machine_status
       - kwargs:
-            timeout: 1200 # in seconds
+            timeout: {{ region.timeout.deployed }}
+            attempts: {{ region.timeout.attempts }}
             req_status: "Deployed"
             ignore_machines:
                - kvm01 # in case it's broken or whatever

--- a/maas/machines/wait_for_ready.sls
+++ b/maas/machines/wait_for_ready.sls
@@ -7,5 +7,8 @@ maas_login_admin:
 wait_for_machines_ready:
   module.run:
   - name: maas.wait_for_machine_status
+  - kwargs:
+        timeout: {{ region.timeout.ready }}
+        attempts: {{ region.timeout.attempts }}
   - require:
     - cmd: maas_login_admin

--- a/maas/machines/wait_for_ready_or_deployed.sls
+++ b/maas/machines/wait_for_ready_or_deployed.sls
@@ -4,12 +4,12 @@ maas_login_admin:
   cmd.run:
   - name: "maas-region apikey --username {{ region.admin.username }} > /var/lib/maas/.maas_credentials"
 
-wait_for_machines_deployed:
+wait_for_machines_ready_or_deployed:
   module.run:
   - name: maas.wait_for_machine_status
   - kwargs:
-        req_status: "Deployed"
-        timeout: {{ region.timeout.deployed }}
+        req_status: "Ready|Deployed"
+        timeout: {{ region.timeout.ready }}
         attempts: {{ region.timeout.attempts }}
   - require:
     - cmd: maas_login_admin

--- a/maas/map.jinja
+++ b/maas/map.jinja
@@ -22,6 +22,10 @@ Debian:
   bind:
     host: 0.0.0.0
     port: 80
+  timeout:
+    ready: 1200
+    deployed: 7200
+    attempts: 0
 {%- endload %}
 
 {%- set region = salt['grains.filter_by'](region_defaults, merge=salt['pillar.get']('maas:region', {})) %}

--- a/tests/pillar/maas_region.sls
+++ b/tests/pillar/maas_region.sls
@@ -23,3 +23,7 @@ maas:
       password: password
       username: maas
     salt_master_ip: 127.0.0.1
+    timeout:
+      deployed: 900
+      ready: 900
+      attempts: 2


### PR DESCRIPTION
This a collection of MaaS comissioning/deploy workarounds that we collected in OPNFV over the last year on a pool of diverse servers (x86_64, AArch64, different vendors/boards etc.).

I know maas.py is slowly being obsoleted, but this PR would help Fuel@OPFNV drop some ugly workarounds (e.g. [1, 2]) until maasng supports something similar to wait_for_* functions.

cc @mpolenchuk

[1] https://github.com/opnfv/fuel/blob/stable/fraser/mcp/config/states/maas#L20-L66
[2] https://gerrit.opnfv.org/gerrit/gitweb?p=fuel.git;a=commitdiff;h=33ac2d8a4e1cb5383f794c88754edc0492004992#patch1